### PR TITLE
Feature/initial dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:feature_base-docker-container
+FROM coco/elasticsearch-reindexer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer
+FROM coco/elasticsearch-reindexer:feature_base-docker-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:feature_tidy-up-error-logging
+FROM coco/elasticsearch-reindexer:0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer
+FROM coco/elasticsearch-reindexer:feature_tidy-up-error-logging

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM coco/elasticsearch-reindexer

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # concept-search-index-mapping
 Elasticsearch mapping for the concept search index.
+
+The Docker image built by this project is based on the elasticsearch-reindexer. It applies the mapping.json file for the concepts index.

--- a/mapping.json
+++ b/mapping.json
@@ -1,0 +1,346 @@
+{
+  "mappings" : {
+    "organisations": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "people": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "indexCompletion": {
+              "type": "completion"
+            },
+            "completionByContext": {
+              "type": "completion",
+              "contexts": [{
+                "name" : "typeContext",
+                "type" : "category",
+                "path" : "_type"
+              }]
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "locations": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "sections": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "subjects": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "brands": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "indexCompletion": {
+              "type": "completion"
+            },
+            "completionByContext": {
+              "type": "completion",
+              "contexts": [{
+                "name" : "typeContext",
+                "type" : "category",
+                "path" : "_type"
+              }]
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "genres": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    },
+    "topics": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "apiUrl": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "directType": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "types": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "prefLabel": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
+        "aliases": {
+          "type": "string",
+          "analyzer": "standard",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Contains version 0.0.1 of the concepts mapping. Requires https://github.com/Financial-Times/elasticsearch-reindexer/pull/2.