### PR TITLE
TME/SmartLogic alias filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:0.0.2-dp-filter-alias-rc1
+FROM coco/elasticsearch-reindexer:0.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:feature_filter-alias
+FROM coco/elasticsearch-reindexer:0.0.2-dp-filter-alias-rc1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:0.0.1
+FROM coco/elasticsearch-reindexer:feature_filter-alias

--- a/alias-filter.json
+++ b/alias-filter.json
@@ -1,0 +1,8 @@
+{
+  "terms": {
+    "authorities": [
+      "TME",
+      "SmartLogic"
+    ]
+  }
+}

--- a/mapping.json
+++ b/mapping.json
@@ -1,346 +1,488 @@
 {
-  "mappings" : {
-    "organisations": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
-      }
-    },
-    "people": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
+   "settings": {
+      "analysis": {
+         "analyzer": {
+            "folding": {
+               "tokenizer": "standard",
+               "filter": [
+                  "lowercase",
+                  "standard",
+                  "ascii_folding"
+               ]
             },
-            "indexCompletion": {
-              "type": "completion"
+            "edge_ngram": {
+               "type": "custom",
+               "tokenizer": "standard",
+               "filter": [
+                  "lowercase",
+                  "ascii_folding",
+                  "edge_ngram_filter"
+               ]
+            }
+         },
+         "filter": {
+            "ascii_folding": {
+               "type": "asciifolding",
+               "preserve_original": true
             },
-            "completionByContext": {
-              "type": "completion",
-              "contexts": [{
-                "name" : "typeContext",
-                "type" : "category",
-                "path" : "_type"
-              }]
+            "edge_ngram_filter": {
+               "type": "edge_ngram",
+               "min_gram": 1,
+               "max_gram": 20
             }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
+         }
       }
-    },
-    "locations": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
-      }
-    },
-    "sections": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
-      }
-    },
-    "subjects": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
-      }
-    },
-    "brands": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
+   },
+   "mappings": {
+      "organisations": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
             },
-            "indexCompletion": {
-              "type": "completion"
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
             },
-            "completionByContext": {
-              "type": "completion",
-              "contexts": [{
-                "name" : "typeContext",
-                "type" : "category",
-                "path" : "_type"
-              }]
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  },
+                  "mentionsCompletion": {
+                     "analyzer": "folding",
+                     "type": "completion"
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
             }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
+         }
+      },
+      "people": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  },
+                  "mentionsCompletion": {
+                     "analyzer": "folding",
+                     "type": "completion"
+                  },
+                  "authorCompletionByContext": {
+                     "analyzer": "folding",
+                     "type": "completion",
+                     "contexts": [
+                        {
+                           "name": "typeContext",
+                           "type": "category",
+                           "path": "_type"
+                        },
+                        {
+                           "name": "authorContext",
+                           "type": "category",
+                           "path": "isFTAuthor"
+                        }
+                     ]
+                  },
+                  "completionByContext": {
+                     "analyzer": "folding",
+                     "type": "completion",
+                     "contexts": [
+                        {
+                           "name": "typeContext",
+                           "type": "category",
+                           "path": "_type"
+                        }
+                     ]
+                  }
+               }
+            },
+            "isFTAuthor": {
+               "type": "text",
+               "index": true
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
             }
-          }
-        }
+         }
+      },
+      "locations": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  },
+                  "mentionsCompletion": {
+                     "analyzer": "folding",
+                     "type": "completion"
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
+            }
+         }
+      },
+      "sections": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
+            }
+         }
+      },
+      "subjects": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
+            }
+         }
+      },
+      "brands": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  },
+                  "completionByContext": {
+                     "analyzer": "folding",
+                     "type": "completion",
+                     "contexts": [
+                        {
+                           "name": "typeContext",
+                           "type": "category",
+                           "path": "_type"
+                        }
+                     ]
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
+            }
+         }
+      },
+      "genres": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
+            }
+         }
+      },
+      "topics": {
+         "properties": {
+            "id": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "apiUrl": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "directType": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "types": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "authorities": {
+               "type": "string",
+               "index": "not_analyzed"
+            },
+            "prefLabel": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  },
+                  "edge_ngram": {
+                     "type": "string",
+                     "analyzer": "edge_ngram",
+                     "search_analyzer": "standard"
+                  },
+                  "mentionsCompletion": {
+                     "analyzer": "folding",
+                     "type": "completion"
+                  }
+               }
+            },
+            "aliases": {
+               "type": "string",
+               "analyzer": "standard",
+               "fields": {
+                  "raw": {
+                     "type": "string",
+                     "index": "not_analyzed"
+                  }
+               }
+            }
+         }
       }
-    },
-    "genres": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
-      }
-    },
-    "topics": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "apiUrl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "directType": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "types": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "prefLabel": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
-        "aliases": {
-          "type": "string",
-          "analyzer": "standard",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        }
-      }
-    }
-  }
+   }
 }


### PR DESCRIPTION
Adds a filter to the index alias, so that only documents with `TME` or `SmartLogic` authorities are returned.