### PR TITLE
Exact Matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,64 @@ The Docker image built by this project is based on the elasticsearch-reindexer. 
 
 # Example Queries
 
+People search using 
+
+* the `edge_ngram` analyzer and a `0.1` boost on a term match
+* the isFTAuthor `1.81 boost
+* the `exact_match` analyzer  
+
+```
+{
+   "size" : 20,
+   "query": {
+      "bool": {
+         "must": {
+            "match" : {
+                "prefLabel.edge_ngram": {
+                    "query":"Donald Gi"
+                }
+            }
+         },
+         "filter": {
+            "term": {
+               "_type": "people"
+            }
+         },
+         "should": [
+            {
+               "term": {
+                  "isFTAuthor": {
+                    "value": "true",
+                    "boost": 1.8
+                  }
+               }
+            },
+            {
+               "match": {
+                  "prefLabel": {
+                    "query": "Donald Gi",
+                    "boost": 0.1
+                  }
+               }
+            },
+            {
+                "match": {
+                   "prefLabel.exact_match": {
+                      "query": "Donald Gi",
+                      "boost": 0.3
+                   }
+                }
+             }
+         ],
+         "minimum_should_match": 0,
+         "boost": 1
+      }
+   }
+}
+
+```
+
+
 Abouts/Mentions using the `edge_ngram` analyzer and a `0.1` boost on a term match:
 
 ```
@@ -90,8 +148,9 @@ Abouts/Mentions with an additional boost using the `exact_match` analyzer:
    }
 }
 ```
+Currently, only BRANDS search uses the suggester
 
-Abouts/Mentions using the `mentionsCompletion` suggester:
+@Deprecated Abouts/Mentions using the `mentionsCompletion` suggester:
 
 ```
 {
@@ -106,7 +165,7 @@ Abouts/Mentions using the `mentionsCompletion` suggester:
 }
 ```
 
-Author boost using the `authorCompletionByContext` suggester:
+@Deprecated Author boost using the `authorCompletionByContext` suggester:
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Docker image built by this project is based on the elasticsearch-reindexer. 
 
 # Example Queries
 
-Abouts/Mentions using the `edge_ngram` analyzer and a `0.1` boost on exact match:
+Abouts/Mentions using the `edge_ngram` analyzer and a `0.1` boost on a term match:
 
 ```
 {
@@ -34,6 +34,53 @@ Abouts/Mentions using the `edge_ngram` analyzer and a `0.1` boost on exact match
                   "prefLabel": {
                      "query": "donald trump",
                      "boost": 0.1
+                  }
+               }
+            }
+         ],
+         "boost": 1
+      }
+   }
+}
+```
+
+Abouts/Mentions with an additional boost using the `exact_match` analyzer:
+
+```
+{
+   "query": {
+      "bool": {
+         "must": {
+            "match": {
+               "prefLabel.edge_ngram": {
+                  "query": "new york"
+               }
+            }
+         },
+         "filter": {
+            "terms": {
+               "_type": [
+                  "people",
+                  "topics",
+                  "organisations",
+                  "locations"
+               ]
+            }
+         },
+         "should": [
+            {
+               "match": {
+                  "prefLabel": {
+                     "query": "new york",
+                     "boost": 0.1
+                  }
+               }
+            },
+            {
+               "term": {
+                  "prefLabel.exact_match": {
+                     "value": "new york",
+                     "boost": 0.5
                   }
                }
             }

--- a/mapping.json
+++ b/mapping.json
@@ -18,6 +18,14 @@
                   "ascii_folding",
                   "edge_ngram_filter"
                ]
+            },
+            "exact_match": {
+               "type": "custom",
+               "tokenizer": "keyword",
+               "filter": [
+                  "lowercase",
+                  "ascii_folding"
+               ]
             }
          },
          "filter": {
@@ -72,6 +80,10 @@
                   "mentionsCompletion": {
                      "analyzer": "folding",
                      "type": "completion"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   }
                }
             },
@@ -121,6 +133,10 @@
                      "type": "string",
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   },
                   "mentionsCompletion": {
                      "analyzer": "folding",
@@ -206,6 +222,10 @@
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
                   },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
+                  },
                   "mentionsCompletion": {
                      "analyzer": "folding",
                      "type": "completion"
@@ -258,6 +278,10 @@
                      "type": "string",
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   }
                }
             },
@@ -307,6 +331,10 @@
                      "type": "string",
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   }
                }
             },
@@ -356,6 +384,10 @@
                      "type": "string",
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   },
                   "completionByContext": {
                      "analyzer": "folding",
@@ -416,6 +448,10 @@
                      "type": "string",
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   }
                }
             },
@@ -465,6 +501,10 @@
                      "type": "string",
                      "analyzer": "edge_ngram",
                      "search_analyzer": "standard"
+                  },
+                  "exact_match": {
+                     "type": "string",
+                     "analyzer": "exact_match"
                   },
                   "mentionsCompletion": {
                      "analyzer": "folding",


### PR DESCRIPTION
Adding an exact_match prefLabel mapping, which will treat each prefLabel as a single token, but will lowercase and ascii fold each term.

Examples:

`"Donald J Trump"` will tokenize to `"donald j trump"`
`"Tokyô"` will tokenize to `["tokyo", "tokyô"]`