### PR TITLE
Update docker image version to 0.0.4 with check severity tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:0.0.3
+FROM coco/elasticsearch-reindexer:0.0.4


### PR DESCRIPTION
- depends on https://github.com/Financial-Times/elasticsearch-reindexer/pull/7 being approved, merged, and a 0.0.4 release created of it