### PR TITLE
Upgrade base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:0.0.4
+FROM coco/elasticsearch-reindexer:0.0.5


### PR DESCRIPTION
https://github.com/Financial-Times/elasticsearch-reindexer/releases/tag/0.0.5