### PR TITLE
Removed capitalized L Smartlogic filter because it is fixed as it should be

### DIFF
--- a/alias-filter.json
+++ b/alias-filter.json
@@ -3,7 +3,6 @@
     "authorities": [
       "TME",
       "Smartlogic",
-      "SmartLogic",
       "ManagedLocation"
     ]
   }


### PR DESCRIPTION
The fixes are already deployed. See:
https://github.com/Financial-Times/smartlogic-concordance-transformer/pull/16
https://github.com/Financial-Times/smartlogic-concept-transformer/pull/15
https://github.com/Financial-Times/aggregate-concept-transformer/pull/37