### PR TITLE
Extended alias filter for public companies regardless of authority

### DIFF
--- a/alias-filter.json
+++ b/alias-filter.json
@@ -1,8 +1,21 @@
 {
-  "terms": {
-    "authorities": [
-      "TME",
-      "Smartlogic"
+  "bool": {
+    "should": [
+      {
+        "terms": {
+          "authorities": [
+            "TME",
+            "Smartlogic"
+          ]
+        }
+      },
+      {
+        "terms": {
+          "directType": [
+            "http://www.ft.com/ontology/company/PublicCompany"
+          ]
+        }
+      }
     ]
   }
 }


### PR DESCRIPTION
By default requesting public companies will return results without restricting for authorities like TME and Smartlogic.
e.g. 
```
{
    "query": {
        "bool": {
            "must": [{
                    "match": { "directType": "http://www.ft.com/ontology/company/PublicCompany" }
                }
            ]
        }
    }
}
```
Will return _58430_ total hits in dev.
Requesting other concepts than public companies keep returning results only if they have TME and Smartlogic authorities.
For the same restriction for public companies, clients could include the restriction in the query:
```
{
    "query": {
        "bool": {
            "must": [{
                    "match": { "directType": "http://www.ft.com/ontology/company/PublicCompany" }
                },
                {
                    "terms": { "authorities": ["TME","Smartlogic"] }            	
                }
            ]
        }
    }
}
```
This query returns _6540_ total hits in dev.