### PR TITLE
Updated base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:0.0.5
+FROM coco/elasticsearch-reindexer:0.0.6-alias-all-rc1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM coco/elasticsearch-reindexer:0.0.6-alias-all-rc1
+FROM coco/elasticsearch-reindexer:0.0.6


### PR DESCRIPTION
See https://github.com/Financial-Times/elasticsearch-reindexer/releases/tag/0.0.6